### PR TITLE
Add support for opensearch 1.3.13

### DIFF
--- a/elasticsearch-dashboard-init/Makefile
+++ b/elasticsearch-dashboard-init/Makefile
@@ -11,7 +11,7 @@ VERSION          = $(TAG)_$(subst /,_,$(PLATFORM))
 
 DASHBOARD_REGISTRY	?= opensearchproject
 DASHBOARD_BIN		?= opensearch-dashboards
-DASHBOARD_TAG		?= 1.3.12
+DASHBOARD_TAG		?= 1.3.13
 DASHBOARD_IMAGE	?= $(shell if [ ! -z $(DASHBOARD_REGISTRY) ]; then echo $(DASHBOARD_REGISTRY)/; fi)$(DASHBOARD_BIN):$(DASHBOARD_TAG)
 
 BUILD_DIRS := bin

--- a/elasticsearch-dashboard-init/Makefile
+++ b/elasticsearch-dashboard-init/Makefile
@@ -11,7 +11,7 @@ VERSION          = $(TAG)_$(subst /,_,$(PLATFORM))
 
 DASHBOARD_REGISTRY	?= opensearchproject
 DASHBOARD_BIN		?= opensearch-dashboards
-DASHBOARD_TAG		?= 1.3.2
+DASHBOARD_TAG		?= 1.3.12
 DASHBOARD_IMAGE	?= $(shell if [ ! -z $(DASHBOARD_REGISTRY) ]; then echo $(DASHBOARD_REGISTRY)/; fi)$(DASHBOARD_BIN):$(DASHBOARD_TAG)
 
 BUILD_DIRS := bin

--- a/elasticsearch-init/Makefile
+++ b/elasticsearch-init/Makefile
@@ -11,7 +11,7 @@ VERSION          = $(TAG)_$(subst /,_,$(PLATFORM))
 
 DB_REGISTRY	?= opensearchproject
 DB_BIN		?= opensearch
-DB_TAG		?= 1.3.12
+DB_TAG		?= 1.3.13
 DB_IMAGE	?= $(shell if [ ! -z $(DB_REGISTRY) ]; then echo $(DB_REGISTRY)/; fi)$(DB_BIN):$(DB_TAG)
 
 BUILD_DIRS := bin

--- a/elasticsearch-init/Makefile
+++ b/elasticsearch-init/Makefile
@@ -11,7 +11,7 @@ VERSION          = $(TAG)_$(subst /,_,$(PLATFORM))
 
 DB_REGISTRY	?= opensearchproject
 DB_BIN		?= opensearch
-DB_TAG		?= 1.3.2
+DB_TAG		?= 1.3.12
 DB_IMAGE	?= $(shell if [ ! -z $(DB_REGISTRY) ]; then echo $(DB_REGISTRY)/; fi)$(DB_BIN):$(DB_TAG)
 
 BUILD_DIRS := bin

--- a/elasticsearch/Makefile
+++ b/elasticsearch/Makefile
@@ -11,7 +11,7 @@ VERSION          = $(TAG)_$(subst /,_,$(PLATFORM))
 
 DB_REGISTRY	?= opensearchproject
 DB_BIN		?= opensearch
-DB_TAG		?= 1.3.2
+DB_TAG		?= 1.3.12
 DB_IMAGE	?= $(shell if [ ! -z $(DB_REGISTRY) ]; then echo $(DB_REGISTRY)/; fi)$(DB_BIN):$(DB_TAG)
 ES_PLUGINS	?= repository-s3, repository-azure, repository-hdfs, repository-gcs
 

--- a/elasticsearch/Makefile
+++ b/elasticsearch/Makefile
@@ -11,7 +11,7 @@ VERSION          = $(TAG)_$(subst /,_,$(PLATFORM))
 
 DB_REGISTRY	?= opensearchproject
 DB_BIN		?= opensearch
-DB_TAG		?= 1.3.12
+DB_TAG		?= 1.3.13
 DB_IMAGE	?= $(shell if [ ! -z $(DB_REGISTRY) ]; then echo $(DB_REGISTRY)/; fi)$(DB_BIN):$(DB_TAG)
 ES_PLUGINS	?= repository-s3, repository-azure, repository-hdfs, repository-gcs
 


### PR DESCRIPTION
Security Admin script is not working in older patch version resulting in security reconfiguration failure. Several other bugs and cve fixes also has been addressed in the latest patches in between. 

https://opensearch.org/docs/latest/security/configuration/security-admin/


Signed-off-by: raihankhan <raihan@appscode.com>